### PR TITLE
bug: 카테고리 null을 허용

### DIFF
--- a/src/main/java/com/economy/community/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/economy/community/repository/PostRepositoryImpl.java
@@ -21,15 +21,15 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     public List<PostResponse> findAllPosts(String category, int page, int size) {
         QPost post = QPost.post;
 
-        CommunityCategory categoryEnum = CommunityCategory.valueOfCategory(category);
-
         BooleanBuilder builder = new BooleanBuilder();
 
         // 동적 조건: 삭제되지 않은 게시글
         builder.and(post.deleted.eq(false));
 
-        // 동적 조건: 특정 카테고리 필터
-        builder.and(post.category.eq(categoryEnum));
+        if (category != null) {
+            CommunityCategory categoryEnum = CommunityCategory.valueOfCategory(category);
+            builder.and(post.category.eq(categoryEnum));
+        }
 
         return queryFactory
                 .select(Projections.constructor(PostResponse.class,

--- a/src/main/java/com/economy/community/service/PostServiceImpl.java
+++ b/src/main/java/com/economy/community/service/PostServiceImpl.java
@@ -27,9 +27,6 @@ public class PostServiceImpl implements PostService {
     @Transactional(readOnly = true)
     @Override
     public List<PostResponse> getPosts(String category, int page, int size) {
-//        if (category == null) {
-//            throw new NullPointerException("category is null");
-//        }
         return postRepository.findAllPosts(category, page, size);
     }
 


### PR DESCRIPTION
## #️⃣ Issue Number
- #8 

## 📝 요약(Summary)

커뮤니티의 전체 게시글 조회 시, 카테고리 값에 null이 들어가면 에러를 발생하는 로직을 사용했기 때문에 에러 발생
null이면 전체를 반환하고, 카테고리가 있으면 카테고리를 반환하도록 하는 로직 작성

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
