### PR TITLE
feat: kafka 메시지 받았을 경우, 댓글 CREATE, DELETE 메시지에 따라 증감 로직 구현

### DIFF
--- a/src/main/java/com/economy/community/domain/CommentEvent.java
+++ b/src/main/java/com/economy/community/domain/CommentEvent.java
@@ -1,0 +1,14 @@
+package com.economy.community.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentEvent {
+    private Long postId;
+    private Long commentId;
+    private String action;  // "CREATE", "DELETE"
+}

--- a/src/main/java/com/economy/community/domain/Post.java
+++ b/src/main/java/com/economy/community/domain/Post.java
@@ -96,6 +96,18 @@ public class Post extends BaseEntity {
         this.viewCount = cachedViewCount;
     }
 
+    // 댓글 추가 시 호출
+    public void incrementCommentsCount() {
+        this.commentsCount++;
+    }
+
+    // 댓글 삭제 시 호출
+    public void decrementCommentsCount() {
+        if (this.commentsCount > 0) {
+            this.commentsCount--;
+        }
+    }
+
     public void validateUserAuthorization(Long userId) {
         if (!this.userId.equals(userId)) {
             throw new IllegalArgumentException("You are not authorized to perform this action on this post");

--- a/src/main/java/com/economy/community/service/KafkaService.java
+++ b/src/main/java/com/economy/community/service/KafkaService.java
@@ -2,4 +2,8 @@ package com.economy.community.service;
 
 
 public interface KafkaService {
+
+    void incrementCommentsCount(Long postId);
+
+    void decrementCommentsCount(Long postId);
 }

--- a/src/main/java/com/economy/community/service/KafkaServiceImpl.java
+++ b/src/main/java/com/economy/community/service/KafkaServiceImpl.java
@@ -1,16 +1,38 @@
 package com.economy.community.service;
 
+import com.economy.community.domain.Post;
 import com.economy.community.dto.UpdatePostUserNickName;
+import com.economy.community.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 @Service
 @RequiredArgsConstructor
 public class KafkaServiceImpl implements KafkaService {
+
+    private final PostRepository postRepository;
+
     @KafkaListener(id = "community-nickname", topics = "updateusernickname")
     public void consume(UpdatePostUserNickName updatePostUserNickName) {
         System.out.println("Consumer IsBilling : " + updatePostUserNickName);
         //실제 동작 로직
+    }
+
+    @Transactional
+    public void incrementCommentsCount(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        post.incrementCommentsCount();
+        postRepository.save(post);
+    }
+
+    @Transactional
+    public void decrementCommentsCount(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        post.decrementCommentsCount();
+        postRepository.save(post);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #20 

## 📝 요약(Summary)

댓글 생성, 삭제 시 kafka 메시지를 받아 댓글수 증감 로직 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6b1eb2eb-5b1a-47e3-a502-803c7261d015)
![image](https://github.com/user-attachments/assets/faa35ada-3c7f-48ef-923a-21a1a29cf3ac)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
